### PR TITLE
feat: 04-08 solutions

### DIFF
--- a/(04-08-2024)Group Anagrams/joshlin/solution.cpp
+++ b/(04-08-2024)Group Anagrams/joshlin/solution.cpp
@@ -1,0 +1,23 @@
+#include <unordered_map>
+#include <vector>
+#include <string>
+#include <algorithm>
+
+using namespace std;
+
+class Solution {
+public:
+    vector<vector<string>> groupAnagrams(vector<string>& strs) {
+        unordered_map<string, vector<string>> cache;
+        vector<vector<string>> res;     
+        for (const auto& word: strs) {
+            string key = word;
+            sort(key.begin(), key.end());
+            cache[key].push_back(word);
+        };
+        for (const auto& [_, group]: cache) {
+            res.push_back(group);
+        };
+        return res;
+    };
+};

--- a/(04-08-2024)Group Anagrams/joshlin/solution.py
+++ b/(04-08-2024)Group Anagrams/joshlin/solution.py
@@ -1,0 +1,30 @@
+from typing import List, Dict
+from collections import defaultdict
+
+class Solution:
+    # m * nlogn
+    def groupAnagrams(self, strs: List[str]) -> List[List[str]]:
+        cache: Dict[str, List[str]] = defaultdict(list)
+        for word in strs:
+            group = ''.join(sorted(word))
+            cache[group].append(word) 
+        return list(cache.values())
+    # m * n * 26
+    def groupAnagrams(self, strs: List[str]) -> List[List[str]]:
+      """
+      Instead of using `key = ''.join(sorted(s))`,
+      lets create an array of character frequences as the key.
+      And to make it a hashable key, we need to convert it to
+      a tuple using `tuple()`
+      """
+      hashMap = defaultdict(list)
+      for string in strs:
+          key = [0] * 26
+          # [0, 0, ..., 0]
+          #  a, b, ..., z
+          for char in string:
+              index = ord(char) - ord('a')
+              key[index] += 1
+          key = tuple(key)
+          hashMap[key].append(string)
+      return hashMap.values()

--- a/(04-08-2024)Group Anagrams/joshlin/solution.ts
+++ b/(04-08-2024)Group Anagrams/joshlin/solution.ts
@@ -1,0 +1,9 @@
+function groupAnagrams(strs: string[]): string[][] {
+  const cache = new Map<string, string[]>();
+  for (const word of strs) {
+      const key = word.split('').sort().join('');
+      if (!cache.has(key)) cache.set(key, [word]);
+      else cache.get(key)?.push(word);
+  };
+  return Array.from(cache.values());
+};


### PR DESCRIPTION
# [49. Group Anagrams](https://leetcode.com/problems/group-anagrams/)

Time Complexity: `O(m*nlogn)`, `O(m*n)`

- 对于`O(m*nlogn)`的算法，我们先把string排序，排序后的结果可以作为hashkey
- 对于`O(m*n*26)`的算法，我们需要构造一个长度为26的array，然后计算frequency，并将array转为hashkey。然而，实际上string的长度在2^26之前，`O(m*nlogn)`都是比`O(m*n*26)`要好的（见下图）。只有当每个string都巨长无比的时候，才能体现出`O(m*n*26)`的优势。

![image](https://github.com/yli2935/daily-leetcode/assets/47153231/7643b99b-140b-4120-9757-d34fdaef2307)
